### PR TITLE
Add question image extraction

### DIFF
--- a/streamlit_pdf_flow.py
+++ b/streamlit_pdf_flow.py
@@ -4,7 +4,7 @@ from tempfile import NamedTemporaryFile
 from jinja2 import Environment, FileSystemLoader
 from weasyprint import HTML
 from pathlib import Path
-from parser.text_extractor import extract_text_from_pdf
+from parser.text_extractor import extract_text_from_pdf, extract_question_images
 from parser.structured_parser import parse_passage_and_questions
 
 # PDF 렌더링용 함수 (메모리 기반 처리)
@@ -33,7 +33,9 @@ if pdf_file and st.button("1️⃣ 텍스트 추출 및 파싱"):
     tmp.flush()
 
     raw_text = extract_text_from_pdf(tmp.name)
+    extract_question_images(tmp.name, "./data/question_images")
     passage, questions = parse_passage_and_questions(raw_text)
+    st.info("문항 이미지는 ./data/question_images 폴더에 저장됩니다.")
 
     st.session_state.parsed_data = {
         "title": title,


### PR DESCRIPTION
## Summary
- add `extract_question_images` for cutting out question areas as images
- save question images when uploading PDFs in the Streamlit app

## Testing
- `python check_testlog.py`

------
https://chatgpt.com/codex/tasks/task_e_684a8de9cb888325987328e30edb94d9