### PR TITLE
Add OCR function and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ```bash
 pip install -r requirements.txt
 ```
+OCR 기능을 사용하려면 `pytesseract`를 설치해야 합니다.
 
 ---
 

--- a/parser/structured_parser.py
+++ b/parser/structured_parser.py
@@ -19,6 +19,7 @@ def should_skip_line(text: str) -> bool:
     return any(re.search(p, text) for p in skip_patterns)
 
 
+def is_passage_intro(text: str) -> bool:
     pattern = r"^(?:\[[^\]]+\]\s*)?다음\s*"
     return bool(re.match(pattern, text)) and "중" not in text[:5]
 def extract_answer(block_lines: List[str]) -> Tuple[List[str], str | None]:
@@ -36,12 +37,6 @@ def extract_answer(block_lines: List[str]) -> Tuple[List[str], str | None]:
         else:
             cleaned.append(line)
     return cleaned, answer
-
-
-        block, answer = extract_answer(block)
-            answer=answer,
-        return True
-    return False
 
 
 

--- a/parser/text_extractor.py
+++ b/parser/text_extractor.py
@@ -1,4 +1,7 @@
+import os
 import fitz  # PyMuPDF
+from PIL import Image
+import pytesseract
 
 
 def extract_text_and_images(pdf_path: str):
@@ -100,3 +103,15 @@ def extract_question_images(pdf_path: str, out_dir: str):
                 pix = page.get_pixmap(clip=fitz.Rect(*region))
                 pix.save(os.path.join(out_dir, f"question_{q_index}.png"))
                 q_index += 1
+
+
+def extract_text_from_images(img_dir: str) -> list[str]:
+    texts = []
+    for img_name in sorted(os.listdir(img_dir)):
+        if not img_name.lower().endswith((".png", ".jpg", ".jpeg")):
+            continue
+        img_path = os.path.join(img_dir, img_name)
+        image = Image.open(img_path)
+        text = pytesseract.image_to_string(image, lang="kor")
+        texts.append(text.strip())
+    return texts

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ streamlit
 jinja2
 weasyprint
 PyMuPDF
+pytesseract
+Pillow

--- a/streamlit_pdf_flow.py
+++ b/streamlit_pdf_flow.py
@@ -4,7 +4,11 @@ from tempfile import NamedTemporaryFile
 from jinja2 import Environment, FileSystemLoader
 from weasyprint import HTML
 from pathlib import Path
-from parser.text_extractor import extract_text_from_pdf, extract_question_images
+from parser.text_extractor import (
+    extract_text_from_pdf,
+    extract_question_images,
+    extract_text_from_images,
+)
 from parser.structured_parser import parse_passage_and_questions
 
 # PDF 렌더링용 함수 (메모리 기반 처리)
@@ -34,8 +38,11 @@ if pdf_file and st.button("1️⃣ 텍스트 추출 및 파싱"):
 
     raw_text = extract_text_from_pdf(tmp.name)
     extract_question_images(tmp.name, "./data/question_images")
+    ocr_results = extract_text_from_images("./data/question_images")
     passage, questions = parse_passage_and_questions(raw_text)
     st.info("문항 이미지는 ./data/question_images 폴더에 저장됩니다.")
+    st.session_state.ocr_results = ocr_results
+    st.write("OCR 결과", ocr_results)
 
     st.session_state.parsed_data = {
         "title": title,


### PR DESCRIPTION
## Summary
- OCR 기능을 위해 `pytesseract`와 `Pillow`를 `requirements.txt`에 추가했습니다.
- `parser/text_extractor.py`에 이미지에서 텍스트를 추출하는 `extract_text_from_images` 함수를 구현했습니다.
- Streamlit 플로우에서 문제 이미지 추출 후 해당 함수를 호출해 OCR 결과를 표시하도록 수정했습니다.
- README에 OCR 사용 시 `pytesseract` 설치 필요하다는 안내를 추가했습니다.
- 누락되었던 `is_passage_intro` 함수 정의를 복구했습니다.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python check_testlog.py`

------
https://chatgpt.com/codex/tasks/task_e_684ab53076948325af1a4d325300d3ac