### PR TITLE
Modify question image extraction to return metadata

### DIFF
--- a/streamlit_pdf_flow.py
+++ b/streamlit_pdf_flow.py
@@ -33,9 +33,10 @@ if pdf_file and st.button("1️⃣ 텍스트 추출 및 파싱"):
     tmp.flush()
 
     raw_text = extract_text_from_pdf(tmp.name)
-    extract_question_images(tmp.name, "./data/question_images")
+    question_image_info = extract_question_images(tmp.name, "./data/question_images")
     passage, questions = parse_passage_and_questions(raw_text)
     st.info("문항 이미지는 ./data/question_images 폴더에 저장됩니다.")
+    st.session_state.question_images = question_image_info
 
     st.session_state.parsed_data = {
         "title": title,


### PR DESCRIPTION
## Summary
- collect question image info in `parser/text_extractor.extract_question_images`
- store returned info in `streamlit_pdf_flow.py`

## Testing
- `python -m py_compile parser/text_extractor.py streamlit_pdf_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_684fbd1ee2608325beaf38c8c89962a5