### PR TITLE
Update question image extraction

### DIFF
--- a/streamlit_pdf_flow.py
+++ b/streamlit_pdf_flow.py
@@ -33,9 +33,10 @@ if pdf_file and st.button("1️⃣ 텍스트 추출 및 파싱"):
     tmp.flush()
 
     raw_text = extract_text_from_pdf(tmp.name)
-    extract_question_images(tmp.name, "./data/question_images")
+    img_results = extract_question_images(tmp.name, "./data/question_images")
     passage, questions = parse_passage_and_questions(raw_text)
     st.info("문항 이미지는 ./data/question_images 폴더에 저장됩니다.")
+    st.json(img_results)
 
     st.session_state.parsed_data = {
         "title": title,


### PR DESCRIPTION
## Summary
- return metadata when extracting question images
- show extracted metadata in Streamlit flow

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_68500c3a65e4832592c3ec2111fd9764