### PR TITLE
Show question images after parsing

### DIFF
--- a/parser/text_extractor.py
+++ b/parser/text_extractor.py
@@ -56,13 +56,15 @@ def extract_text_from_pdf(pdf_path: str) -> str:
 
 
 def extract_question_images(pdf_path: str, out_dir: str):
-    """문항 번호 기준으로 영역을 잘라 이미지로 저장한다."""
+    """문항 번호 기준으로 영역을 잘라 이미지로 저장하고 경로 리스트를 반환한다."""
     import os
     import re
 
     os.makedirs(out_dir, exist_ok=True)
 
     pattern = re.compile(r"^(?:\(\d+\)|\d+\s*[.)])")
+
+    saved_paths = []
 
     with fitz.open(pdf_path) as doc:
         q_index = 1
@@ -85,8 +87,10 @@ def extract_question_images(pdf_path: str, out_dir: str):
 
                 if pattern.match(text):
                     if region:
+                        img_path = os.path.join(out_dir, f"question_{q_index}.png")
                         pix = page.get_pixmap(clip=fitz.Rect(*region))
-                        pix.save(os.path.join(out_dir, f"question_{q_index}.png"))
+                        pix.save(img_path)
+                        saved_paths.append(img_path)
                         q_index += 1
                     region = list(block["bbox"])
                 elif region:
@@ -97,6 +101,10 @@ def extract_question_images(pdf_path: str, out_dir: str):
                     region[3] = max(region[3], b[3])
 
             if region:
+                img_path = os.path.join(out_dir, f"question_{q_index}.png")
                 pix = page.get_pixmap(clip=fitz.Rect(*region))
-                pix.save(os.path.join(out_dir, f"question_{q_index}.png"))
+                pix.save(img_path)
+                saved_paths.append(img_path)
                 q_index += 1
+
+    return saved_paths

--- a/streamlit_pdf_flow.py
+++ b/streamlit_pdf_flow.py
@@ -6,6 +6,7 @@ from xhtml2pdf import pisa
 from pathlib import Path
 from parser.text_extractor import extract_text_from_pdf, extract_question_images
 from parser.structured_parser import parse_passage_and_questions
+from typing import List
 
 # PDF 렌더링용 함수 (메모리 기반 처리)
 
@@ -33,9 +34,11 @@ if pdf_file and st.button("1️⃣ 텍스트 추출 및 파싱"):
     tmp.flush()
 
     raw_text = extract_text_from_pdf(tmp.name)
-    extract_question_images(tmp.name, "./data/question_images")
+    img_paths = extract_question_images(tmp.name, "./data/question_images")
     passage, questions = parse_passage_and_questions(raw_text)
     st.info("문항 이미지는 ./data/question_images 폴더에 저장됩니다.")
+
+    st.session_state.question_images = img_paths
 
     st.session_state.parsed_data = {
         "title": title,
@@ -51,6 +54,19 @@ if pdf_file and st.button("1️⃣ 텍스트 추출 및 파싱"):
     }
     st.success("✅ 파싱 완료! 아래에서 수정하고 PDF를 생성하세요.")
     st.json(st.session_state.parsed_data)
+
+    st.subheader("🖼 추출된 문항 이미지")
+    for i, path in enumerate(st.session_state.question_images, start=1):
+        last_sent = questions[i-1].stem.strip().splitlines()[-1]
+        edited = st.text_input(
+            f"{i}번 마지막 문장", value=last_sent, key=f"img_last_{i}")
+        st.image(path, caption=Path(path).name)
+
+        q_data = st.session_state.parsed_data["questions"][i-1]
+        lines = q_data["question"].splitlines()
+        if lines:
+            lines[-1] = edited
+            q_data["question"] = "\n".join(lines)
 
 if "parsed_data" in st.session_state:
     data = st.session_state.parsed_data


### PR DESCRIPTION
## Summary
- return saved image paths from `extract_question_images`
- store image paths in session state and show each after parsing
- allow editing of last sentence for each image

## Testing
- `python -m py_compile parser/text_extractor.py streamlit_pdf_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_68500c3ae9e08325bf62de1bcd604167